### PR TITLE
Fix support for 1.15 and future proof

### DIFF
--- a/Plugin/src/main/java/me/aboodyy/itemmanager/ItemManager.java
+++ b/Plugin/src/main/java/me/aboodyy/itemmanager/ItemManager.java
@@ -49,7 +49,11 @@ public class ItemManager extends JavaPlugin {
 
     public void onEnable() {
         pl = this;
-        isLegacy = !Bukkit.getBukkitVersion().contains("1.13") && !Bukkit.getBukkitVersion().contains("1.14");
+		if (Bukkit.getVersion().contains("1.6") || Bukkit.getVersion().contains("1.7") || Bukkit.getVersion().contains("1.8") || Bukkit.getVersion().contains("1.9") 
+				|| Bukkit.getVersion().contains("1.10") || Bukkit.getVersion().contains("1.11") || Bukkit.getVersion().contains("1.12"))
+			isLegacy = true;
+		else
+			isLegacy = false;
 
         SpigotUpdateChecker updateChecker = new SpigotUpdateChecker();
 


### PR DESCRIPTION
Basicly changed the way of setting the isLegacy boolean so it is future proof and you dont need to update it every minecraft major update.